### PR TITLE
Bug/rexp with zero

### DIFF
--- a/R/sample.R
+++ b/R/sample.R
@@ -25,7 +25,7 @@ rmo_esm <- function(n, d, intensities) {
   for (k in 1:n) {
     value <- rep(Inf, d)
     for (j in 1:(2^d - 1)) {
-      E <- rexp(1, intensities[[j]]) # nolint
+      E <- rexp_if_rate_zero_then_infinity(1, intensities[[j]]) # nolint
       for (i in 1:d) {
         if (is_within(i, j))
           value[i] <- min(c(value[[i]], E))
@@ -150,4 +150,15 @@ rmo_ex_arnold_sorted <- function(d, generator_list) {
 
   epsilon + c(rep(0, num_affected),
               rmo_ex_arnold_sorted(d-num_affected, generator_list))
+}
+
+#' @importFrom stats rexp
+#' @keywords internal
+#' @noRd
+rexp_if_rate_zero_then_infinity <- function(n, rate) { # nolint
+  if (rate == 0) {
+    return(rep(Inf, n))
+  } else {
+    return(rexp(n, rate))
+  }
 }

--- a/tests/testthat/helper__sample.R
+++ b/tests/testthat/helper__sample.R
@@ -91,7 +91,10 @@ test__rmo_esm_bivariate_R <- function(n, d, intensities) { # nolint
 
   out <- matrix(0, nrow = n, ncol = 2)
     for (i in 1:n) {
-      out[i, ] <- pmin(1/intensities[1:2] * stats::rexp(2), c(1, 1)/intensities[3] * stats::rexp(1))
+      E1 <- rexp_if_rate_zero_then_infinity(1, intensities[1]) # nolint
+      E2 <- rexp_if_rate_zero_then_infinity(1, intensities[2]) # nolint
+      E3 <- rexp_if_rate_zero_then_infinity(1, intensities[3]) # nolint
+      out[i, ] <- pmin(c(E1, E2), E3)
     }
 
   out

--- a/tests/testthat/helper__sample.R
+++ b/tests/testthat/helper__sample.R
@@ -60,8 +60,8 @@ test__rmo_assertparameters_R <- function(n, d, intensities) { # nolint
 test__rmo_assertexparameters_R <- function(n, d, ex_intensities) { # nolint
   assertthat::assert_that(assertthat::is.count(n), assertthat::is.count(d))
   assertthat::assert_that(is.numeric(ex_intensities), all(ex_intensities >= 0), length(ex_intensities) == d) # nolint
-  marginal_intensities <- vapply(1:d, function(x) sum(vapply(0:(x-1), function(y) choose(x-1, y) * ex_intensities[y+1], FUN.VALUE=0.5)), FUN.VALUE=0.5) # nolint
-  assertthat::assert_that(all(marginal_intensities > 0))
+  marginal_intensities <- sum(vapply(0:(d-1), function(y) choose(d-1, y) * ex_intensities[y+1], FUN.VALUE=0.5)) # nolint
+  assertthat::assert_that(marginal_intensities > 0)
 
   invisible(TRUE)
 }

--- a/tests/testthat/test__arnold.R
+++ b/tests/testthat/test__arnold.R
@@ -33,4 +33,14 @@ test_that("Arnold model implementation for d = 2", {
   args[["intensities"]] <- c(0.1, 0.005, 2)
   expect_equal_sampling_result("rmo_arnold", "test__rmo_arnold_bivariate_R",
                                args, n, use_seed)
+
+  ## comonotone
+  args[["intensities"]] <- c(0, 0, 1)
+  expect_equal_sampling_result("rmo_arnold", "test__rmo_arnold_bivariate_R",
+                               args, n, use_seed)
+
+  ## independence
+  args[["intensities"]] <- c(1, 1, 0)
+  expect_equal_sampling_result("rmo_arnold", "test__rmo_arnold_bivariate_R",
+                               args, n, use_seed)
 })

--- a/tests/testthat/test__esm.R
+++ b/tests/testthat/test__esm.R
@@ -31,4 +31,14 @@ test_that("ESM implementation for d = 2", {
   args[["intensities"]] <- c(0.1, 0.005, 2)
   expect_equal_sampling_result("rmo_esm", "test__rmo_esm_bivariate_R",
                                args, n, use_seed)
+
+  ## comonotone
+  args[["intensities"]] <- c(0, 0, 1)
+  expect_equal_sampling_result("rmo_esm", "test__rmo_esm_bivariate_R",
+                               args, n, use_seed)
+
+  ## independence
+  args[["intensities"]] <- c(1, 1, 0)
+  expect_equal_sampling_result("rmo_esm", "test__rmo_esm_bivariate_R",
+                               args, n, use_seed)
 })

--- a/tests/testthat/test__ex_arnold.R
+++ b/tests/testthat/test__ex_arnold.R
@@ -21,6 +21,16 @@ test_that("Exchangeable Arnold model for d = 2", {
   args[["ex_intensities"]] <- c(3, 0.2)
   expect_equal_sampling_result("rmo_ex_arnold", "test__rmo_ex_arnold_bivariate_R",
                                args, n, use_seed)
+
+  ## comonotone
+  args[["ex_intensities"]] <- c(0, 1)
+  expect_equal_sampling_result("rmo_ex_arnold", "test__rmo_ex_arnold_bivariate_R",
+                               args, n, use_seed)
+
+  ## independence
+  args[["ex_intensities"]] <- c(1, 0)
+  expect_equal_sampling_result("rmo_ex_arnold", "test__rmo_ex_arnold_bivariate_R",
+                               args, n, use_seed)
 })
 
 
@@ -29,7 +39,7 @@ test_that("Exchangeable Arnold model for d = 2", {
 ## parameters is equivalent for d = 5 and different choices
 ## for the ex_intensity vector..
 test_that("Alternative implementation", {
-  n <- 100L
+  n <- 25L
 
   ## all equal
   args <- list("d" = 5L, ex_intensities = rep(1, 5L))
@@ -37,7 +47,17 @@ test_that("Alternative implementation", {
                                args, n, use_seed)
 
   ## heterogeneous ex_intensity vector
-  args <- list("d" = 5L, ex_intensities = c(0.4, 0.3, 0.2, 0.2, 0.1))
+  args[["ex_intensities"]] <- c(0.4, 0.3, 0.2, 0.2, 0.1)
+  expect_equal_sampling_result("rmo_ex_arnold", "test__rmo_ex_arnold_alternative_R",
+                               args, n, use_seed)
+
+  ## comonotone
+  args[["ex_intensities"]] <- c(0, 0, 0, 0, 1)
+  expect_equal_sampling_result("rmo_ex_arnold", "test__rmo_ex_arnold_alternative_R",
+                               args, n, use_seed)
+
+  ## independence
+  args[["ex_intensities"]] <- c(1, 0, 0, 0, 0)
   expect_equal_sampling_result("rmo_ex_arnold", "test__rmo_ex_arnold_alternative_R",
                                args, n, use_seed)
 })


### PR DESCRIPTION
## Related issues

Closes #13 

## Checklist

- [x] `R CMD CHECK` successful
- [x] tests included
- [x] documentation included or updated
- [x] commit messages follow [commit guidelines](https://udacity.github.io/git-styleguide/)

Only for new or refactored algorithms:

- ~~benchmarks (and comparison with the previous version) included~~

Optional, but recommended:

- [x] code passes `lintr::lint_package()` without errors

## Description

Proposed changes:
- Fix problem with rate zero by using a wrapper function
- Fix bug in helper function for test
