### PR TITLE
refactor: `rmo_esm`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rmo
 Title: A package for the Marshall-Olkin distribution
-Version: 0.2.0.9006
+Version: 0.2.0.9007
 Authors@R:
   person(given = "Henrik",
     family = "Sloot",

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,9 @@
 - Refactoring and additional tests
 - Fix problem with `int32` is `is_within` function
 - Refactor custom assertions
-- Add S4 classes for evaluating Bernstein Functions and their higher-order alternating, iterated forward differences.
+- Add S4 classes for evaluating Bernstein Functions and their higher-order alternating, iterated forward differences
+- Better test cases and increased test coverage
+- Refactor `Rcpp__rmo_esm` for increased performance
 
 # rmo 0.2.0
 

--- a/R/sample.R
+++ b/R/sample.R
@@ -4,27 +4,37 @@
 
 #' Sample from a Marshall--Olkin distribution
 #'
+#' @description
 #' Draws `n` independent samples from a `d`-variate Marshall-Olkin distribution
 #' with shock rates `intensities`.
 #'
-#' - The shock intensities must be stored in a vector of length \eqn{2^d-1}.
-#' - A shock intensity of zero corresponds to an almost surely infinite shock.
-#' - We use a binary representation to map a non-empty subset \eqn{J} of \eqn{\{
-#' 1, \ldots, d\}}{{1, \ldots, d}} to integers \eqn{j} of \eqn{1, \ldots, 2^d-1}. In
-#' particular, \eqn{i} is a component in the set \eqn{J} corresponding to the integer \eqn{j} iff
-#' \eqn{j = \sum_{k=0}^\infty a_k 2^k}{\sum a[k] * 2^k} and \eqn{a_{i-1} = 1}{a[i-1] = 1}.
-#'
-#' @param n number of samples
-#' @param d dimension
+#' @param n Number of samples
+#' @param d Dimension
 #' @param intensities Marshall-Olkin intensity rates
 #'
-#' @return `rmo_esm` implements the *exogenous shock model* representation and
-#' returns an \eqn{n \times d}{n x d} numeric matrix with the rows corresponding
-#' to independent and identically distributed samples of a \eqn{d} variate
-#' Marshall-Olkin distribution with parameters `intensities`.
+#' @details
+#' __The shock intensities__:
+#' - The shock `intensities` must be stored in a vector of length
+#'    \eqn{2^d-1}.
+#' - A shock intensity of zero corresponds to an almost surely infinite
+#'    shock.
+#' - We use a binary representation to map a non-empty subset \eqn{J}
+#'    of \eqn{\{ 1, \ldots, d\}}{{1, \ldots, d}} to integers \eqn{j} of
+#'    \eqn{1, \ldots, 2^d-1}.
+#'    In particular, \eqn{i} is a component in the set \eqn{J} corresponding to
+#'    the integer \eqn{j} if, and only if,
+#'    \eqn{j = \sum_{k=0}^\infty a_k 2^k}{\sum a[k] * 2^k}
+#'    and \eqn{a_{i-1} = 1}{a[i-1] = 1}.
 #'
-#' @section References: For more information on these algorithms, see J.-F. Mai,
-#' M. Scherer, "Simulating Copulas", World Scientific (2017), pp. 104 psqq.
+#' __The exogenous shock model__ simulates a Marshall--Olkin distributed random
+#' vector via exponentially distributed shock times for all non-empty subsets,
+#' see \insertCite{@see pp. 104 psqq. @Mai2017a}{rmo} and
+#' \insertCite{Marshall1967a}{rmo}.
+#'
+#' @return `rmo_esm` implements the *exogenous shock model* representation and
+#'   returns an \eqn{n \times d}{n x d} numeric matrix with the rows
+#'   corresponding to independent and identically distributed samples of a
+#'   \eqn{d} variate Marshall-Olkin distribution with parameters `intensities`.
 #'
 #' @family samplers
 #'
@@ -32,6 +42,9 @@
 #' rmo_esm(10L, 2L, c(0.4, 0.3, 0.2))
 #' rmo_esm(10L, 2L, c(1, 1, 0))         ## independence
 #' rmo_esm(10L, 2L, c(0, 0, 1))         ## comonotone
+#'
+#' @references
+#'  \insertAllCited{}
 #'
 #' @include assert.R RcppExports.R
 #' @importFrom stats rexp
@@ -48,15 +61,24 @@ rmo_esm <- function(n, d, intensities) {
 
 #' @rdname rmo_esm
 #'
+#' @details
+#' __The Arnold model__ simulates a Marshall--Olkin distributed random variable
+#' by simulating a marked homogeneous Poisson process and where the
+#' inter-arrival times correspond to shock shock-arrival times and the
+#' marks to the specific shocks, see \insertCite{@see Sec. 3.1.2 @Mai2017a}{rmo}
+#' and \insertCite{Arnold1975a}{rmo}.
+#'
 #' @return `rmo_arnold` implements the *Arnold model* representation and returns
-#' an \eqn{n \times d}{n x d} numeric matrix with the rows corresponding to
-#' independent and identically distributed samples of a \eqn{d} variate
-#' Marshall-Olkin distribution with parameters `intensities`.
+#'  an \eqn{n \times d}{n x d} numeric matrix with the rows corresponding to
+#'  independent and identically distributed samples of a \eqn{d} variate
+#'  Marshall-Olkin distribution with parameters `intensities`.
 #'
 #' @examples
 #' rmo_arnold(10L, 2L, c(0.4, 0.3, 0.2))
 #' rmo_arnold(10L, 2L, c(1, 1, 0))         ## independence
 #' rmo_arnold(10L, 2L, c(0, 0, 1))         ## comonotone
+#'
+#' @family samplers
 #'
 #' @include assert.R RcppExports.R
 #' @importFrom stats rexp

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ![minimal R
 version](https://img.shields.io/badge/R%3E%3D-3.6.0-6666ff.svg)
-![packageversion](https://img.shields.io/badge/Package%20version-0.2.0.9006-orange.svg?style=flat-square)
+![packageversion](https://img.shields.io/badge/Package%20version-0.2.0.9007-orange.svg?style=flat-square)
 [![Project Status: WIP – Initial development is in progress, but there
 has not yet been a stable, usable release suitable for the
 public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
@@ -19,7 +19,7 @@ status](https://ci.appveyor.com/api/projects/status/github/hsloot/rmo?branch=mas
 coverage](https://codecov.io/gh/hsloot/rmo/branch/master/graph/badge.svg)](https://codecov.io/gh/hsloot/rmo?branch=master)
 [![Lifecycle:
 experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://www.tidyverse.org/lifecycle/#experimental)
-[![Last-changedate](https://img.shields.io/badge/last%20change-2020--04--12-yellowgreen.svg)](/commits/master)
+[![Last-changedate](https://img.shields.io/badge/last%20change-2020--04--13-yellowgreen.svg)](/commits/master)
 <!-- badges: end -->
 
 An R package for the *Marshall-Olkin distribution*: algorithms for the

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "description": "\n  The package contains an implementation of the Marshall-Olkin distribution and methods for estimation, simulation, and construction.",
   "name": "rmo: A package for the Marshall-Olkin distribution",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.2.0.9006",
+  "version": "0.2.0.9007",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
@@ -133,7 +133,7 @@
   "codeRepository": "https://hsloot.github.io/rmo/",
   "releaseNotes": "https://github.com/hsloot/rmo/blob/master/NEWS.md",
   "readme": "https://github.com/hsloot/rmo/blob/master/README.md",
-  "fileSize": "38.859KB",
+  "fileSize": "45.596KB",
   "contIntegration": [
     "https://travis-ci.org/hsloot/rmo",
     "https://ci.appveyor.com/project/hsloot/rmo",

--- a/inst/REFERENCES.bib
+++ b/inst/REFERENCES.bib
@@ -1,11 +1,39 @@
+@Article{Marshall1967a,
+  author    = {Marshall, Albert W. and Olkin, Ingram},
+  journal   = {Journal of the American Statistical Association},
+  title     = {A multivariate exponential distribution},
+  year      = {1967},
+  number    = {317},
+  pages     = {30--44},
+  volume    = {62},
+  doi       = {10.2307/2282907}
+}
+
+@Article{Arnold1975a,
+  author    = {Arnold, Barry C.},
+  journal   = {Sankhy{\={a}}: The Indian Journal of Statistics, Series A},
+  title     = {A characterization of the exponential distribution by multivariate geometric compounding},
+  year      = {1975},
+  number    = {1},
+  pages     = {164--173},
+  volume    = {37}
+}
+
 @Book{Schilling2012a,
   author    = {Schilling, Ren{\'e} L. and Song, Renming and Vondracek, Zoran},
   publisher = {De Gruyter},
   title     = {{B}ernstein functions},
   year      = {2012},
   edition   = {2},
-  isbn      = {978-3-11-026933-8},
-  series    = {De Gruyter Studies in Mathematics},
-  volume    = {37},
   doi       = {10.1515/9783110269338}
+}
+
+@Book{Mai2017a,
+  author    = {Mai, Jan-Frederik and Scherer, Matthias},
+  publisher = {World Scientific},
+  title     = {Simulating copulas: stochastic models, sampling algorithms and applications},
+  year      = {2017},
+  edition   = {2},
+  series    = {Series in Quantitative Finance},
+  doi       = {10.1142/10265}
 }

--- a/inst/Rprofile/prof_v0_2_0_9007.R
+++ b/inst/Rprofile/prof_v0_2_0_9007.R
@@ -1,0 +1,113 @@
+# nolint start
+#+ setup
+library("rmo")
+library("magrittr")
+library("ggplot2")
+library("microbenchmark")
+
+source(system.file("Rsource", "parameter_generator.R",
+  package="rmo", mustWork=TRUE))
+
+use_seed <- 1632L
+n <- 1e4L
+d1 <- 2L
+d2 <- 4L
+d <- d1+d2
+
+
+#' ## Cuadras-Augé Parameter
+#'
+#' We first test the speed on a parametrisation, where we would expect
+#' performance increases (parameterisations with many zeros):
+#' The Cuadras-Augé (individual and global shocks) distribution.
+#+ r parameters-first
+scale <- 0.3
+alpha <- scale
+beta <- 0
+rate <- 0
+rate_killing <- 0
+rate_drift <- scale
+
+ex_intensities <- ex_intensities_linear(d, scale=scale)
+intensities <- intensities_linear(d, scale=scale)
+
+#+ r v0.2.0.9007-first
+set.seed(use_seed)
+mb1 <- microbenchmark(
+  ESM = rmo_esm(n, d, intensities=intensities),
+  Arnold = rmo_arnold(n, d, intensities=intensities),
+  Ex_Arnold = rmo_ex_arnold(n, d, ex_intensities=ex_intensities),
+  LFM_CPP = rmo_lfm_cpp(n, d, rate=rate, rate_killing=rate_killing,
+    rate_drift=rate_drift, rjump_name="rposval",
+    rjump_arg_list=list("value"=1)),
+  Cuadras_Auge = rmo_esm_cuadras_auge(n, d, alpha, beta)
+)
+detach("package:rmo", unload = TRUE)
+
+#+ r v0.2.0-first
+tmpdir <- tempdir()
+suppressMessages(devtools::install_github("hsloot/rmo@v0.2.0", lib = tmpdir, quiet = TRUE))
+library(rmo, lib.loc = tmpdir)
+set.seed(use_seed)
+
+mb2 <- microbenchmark(
+  ESM = rmo_esm(n, d, intensities=intensities),
+  Arnold = rmo_arnold(n, d, intensities=intensities),
+  Ex_Arnold = rmo_ex_arnold(n, d, ex_intensities=ex_intensities),
+  LFM_CPP = rmo_lfm_cpp(n, d, rate=rate, rate_killing=rate_killing,
+    rate_drift=rate_drift, rjump_name="rposval",
+    rjump_arg_list=list("value"=1)),
+  Cuadras_Auge = rmo_esm_cuadras_auge(n, d, alpha, beta)
+)
+detach("package:rmo", unload = TRUE)
+
+#+ r plot-results-first
+mb1 %>%
+  autoplot()
+mb2 %>%
+  autoplot()
+
+
+
+#' ## More general parametrisation
+#'
+#' We also test the speed on a general, asymmetric parametrisation
+#' to assure that there are non performance decreases.
+#+ r parameters-second
+lambda <- 0.2
+eta <- 0.5
+alpha <- 0.4
+a <- 0.3
+
+intensities <- intensities_hierarchical(d1, d2, lambda=lambda,
+  eta=eta, alpha=alpha, a=a)
+
+#+ r v0.2.0.9007-second
+library(rmo)
+set.seed(use_seed)
+mb1 <- microbenchmark(
+  ESM = rmo_esm(n, d, intensities=intensities),
+  Arnold = rmo_arnold(n, d, intensities=intensities)
+)
+detach("package:rmo", unload = TRUE)
+
+#+ r v0.2.0-second
+tmpdir <- tempdir()
+suppressMessages(devtools::install_github("hsloot/rmo@v0.2.0", lib = tmpdir, quiet = TRUE))
+library(rmo, lib.loc = tmpdir)
+set.seed(use_seed)
+
+mb2 <- microbenchmark(
+  ESM = rmo_esm(n, d, intensities=intensities),
+  Arnold = rmo_arnold(n, d, intensities=intensities)
+)
+detach("package:rmo", unload = TRUE)
+
+#+ r plot-results-second
+mb1 %>%
+  autoplot()
+mb2 %>%
+  autoplot()
+
+# print(unlink(tmpdir, recursive = TRUE))
+# nolint end

--- a/inst/Rsource/parameter_generator.R
+++ b/inst/Rsource/parameter_generator.R
@@ -15,7 +15,7 @@ ex_intensities2intensities <- function(ex_intensities) {
   for (j in seq_along(intensities)) {
     count <- 0
     for (i in 1:d) {
-      count <- count + Rcpp__is_within(i, j)
+      count <- count + rmo:::Rcpp__is_within(i, j)
     }
     intensities[j] <- ex_intensities[count]
   }
@@ -50,6 +50,21 @@ ex_intensities_linear <- function(d, scale) {
 #' @noRd
 intensities_linear <- function(d, scale) {
   ex_intensities2intensities(ex_intensities_linear(d, scale))
+}
+
+
+#' @keywords internal
+#' @noRd
+ex_intensities_cuadras_auge <- function(d, alpha, beta) {
+  ex_intensities_linear(d, scale=alpha) +
+    ex_intensities_constant(d, constant=beta)
+}
+
+#' @keywords internal
+#' @noRd
+intensities_cuadras_auge <- function(d, alpha, beta) {
+  ex_intensities2intensities(ex_intensities_cuadras_auge(d,
+    alpha=alpha, beta=beta))
 }
 
 
@@ -115,10 +130,10 @@ intensities_hierarchical <- function(d1, d2, lambda, eta, a, alpha) { # nolint
     count_1 <- 0
     count_2 <- 0
     for (i in 1:d1) {
-      count_1 <- count_1 + Rcpp__is_within(i, j)
+      count_1 <- count_1 + rmo:::Rcpp__is_within(i, j)
     }
     for (i in 1:d2) {
-      count_2 <- count_2 + Rcpp__is_within(d1+i, j)
+      count_2 <- count_2 + rmo:::Rcpp__is_within(d1+i, j)
     }
 
     if (count_1 > 0 && count_2 == 0) {

--- a/man/rmo_esm.Rd
+++ b/man/rmo_esm.Rd
@@ -10,17 +10,17 @@ rmo_esm(n, d, intensities)
 rmo_arnold(n, d, intensities)
 }
 \arguments{
-\item{n}{number of samples}
+\item{n}{Number of samples}
 
-\item{d}{dimension}
+\item{d}{Dimension}
 
 \item{intensities}{Marshall-Olkin intensity rates}
 }
 \value{
 \code{rmo_esm} implements the \emph{exogenous shock model} representation and
-returns an \eqn{n \times d}{n x d} numeric matrix with the rows corresponding
-to independent and identically distributed samples of a \eqn{d} variate
-Marshall-Olkin distribution with parameters \code{intensities}.
+returns an \eqn{n \times d}{n x d} numeric matrix with the rows
+corresponding to independent and identically distributed samples of a
+\eqn{d} variate Marshall-Olkin distribution with parameters \code{intensities}.
 
 \code{rmo_arnold} implements the \emph{Arnold model} representation and returns
 an \eqn{n \times d}{n x d} numeric matrix with the rows corresponding to
@@ -32,20 +32,32 @@ Draws \code{n} independent samples from a \code{d}-variate Marshall-Olkin distri
 with shock rates \code{intensities}.
 }
 \details{
+\strong{The shock intensities}:
 \itemize{
-\item The shock intensities must be stored in a vector of length \eqn{2^d-1}.
-\item A shock intensity of zero corresponds to an almost surely infinite shock.
-\item We use a binary representation to map a non-empty subset \eqn{J} of \eqn{\{
-1, \ldots, d\}}{{1, \ldots, d}} to integers \eqn{j} of \eqn{1, \ldots, 2^d-1}. In
-particular, \eqn{i} is a component in the set \eqn{J} corresponding to the integer \eqn{j} iff
-\eqn{j = \sum_{k=0}^\infty a_k 2^k}{\sum a[k] * 2^k} and \eqn{a_{i-1} = 1}{a[i-1] = 1}.
-}
-}
-\section{References}{
- For more information on these algorithms, see J.-F. Mai,
-M. Scherer, "Simulating Copulas", World Scientific (2017), pp. 104 psqq.
+\item The shock \code{intensities} must be stored in a vector of length
+\eqn{2^d-1}.
+\item A shock intensity of zero corresponds to an almost surely infinite
+shock.
+\item We use a binary representation to map a non-empty subset \eqn{J}
+of \eqn{\{ 1, \ldots, d\}}{{1, \ldots, d}} to integers \eqn{j} of
+\eqn{1, \ldots, 2^d-1}.
+In particular, \eqn{i} is a component in the set \eqn{J} corresponding to
+the integer \eqn{j} if, and only if,
+\eqn{j = \sum_{k=0}^\infty a_k 2^k}{\sum a[k] * 2^k}
+and \eqn{a_{i-1} = 1}{a[i-1] = 1}.
 }
 
+\strong{The exogenous shock model} simulates a Marshall--Olkin distributed random
+vector via exponentially distributed shock times for all non-empty subsets,
+see \insertCite{@see pp. 104 psqq. @Mai2017a}{rmo} and
+\insertCite{Marshall1967a}{rmo}.
+
+\strong{The Arnold model} simulates a Marshall--Olkin distributed random variable
+by simulating a marked homogeneous Poisson process and where the
+inter-arrival times correspond to shock shock-arrival times and the
+marks to the specific shocks, see \insertCite{@see Sec. 3.1.2 @Mai2017a}{rmo}
+and \insertCite{Arnold1975a}{rmo}.
+}
 \examples{
 rmo_esm(10L, 2L, c(0.4, 0.3, 0.2))
 rmo_esm(10L, 2L, c(1, 1, 0))         ## independence
@@ -56,7 +68,15 @@ rmo_arnold(10L, 2L, c(1, 1, 0))         ## independence
 rmo_arnold(10L, 2L, c(0, 0, 1))         ## comonotone
 
 }
+\references{
+\insertAllCited{}
+}
 \seealso{
+Other samplers: 
+\code{\link{rmo_esm_cuadras_auge}()},
+\code{\link{rmo_ex_arnold}()},
+\code{\link{rmo_lfm_cpp}()}
+
 Other samplers: 
 \code{\link{rmo_esm_cuadras_auge}()},
 \code{\link{rmo_ex_arnold}()},

--- a/src/sample.cpp
+++ b/src/sample.cpp
@@ -20,12 +20,14 @@ NumericMatrix Rcpp__rmo_esm(unsigned int n, unsigned int d, NumericVector intens
       checkUserInterrupt();
 
     value = NumericVector(d, R_PosInf);
-    for (unsigned int j=0; j < pow(2., d)-1; j++) {
+    for (unsigned int j=0; j < (1<<d)-1; j++) {
       intensity = intensities[j];
-      shock_time = (intensity == 0 ? R_PosInf : R::exp_rand() / intensity);
-      for (unsigned int i=0; i<d; i++) {
-        if (is_within(i+1, j+1)) {
-          value[i] = min2(value[i], shock_time);
+      if (intensity > 0) {
+        shock_time = R::exp_rand() / intensity;
+        for (unsigned int i=0; i<d; i++) {
+          if (is_within(i+1, j+1)) {
+            value[i] = min2(value[i], shock_time);
+          }
         }
       }
     }

--- a/tests/testthat/test__esm.R
+++ b/tests/testthat/test__esm.R
@@ -2,76 +2,93 @@ context("Exogenous shock model")
 use_seed <- 1632L
 n <- 100L
 
-
-## #### Test implementation for the bivariate case ####
+# #### Test implementation for the bivariate case ####
 #
 # Test that the implementation of the exogenous shock model works as expected
 # for the bivaraite case and different choices for the intensity vector.
 test_that("ESM implementation for d = 2", {
+  d <- 2L
+
   ## all equal
-  args <- list("d" = 2L, "intensities" = c(1, 1, 1))
+  args <- list("d" = d, "intensities" = c(1, 1, 1))
   expect_equal_sampling_result("rmo_esm", "test__rmo_esm_bivariate_R",
-                               args, n, use_seed)
-
-  ## exchangeable, low, high
-  args <- list("d" = 2L, "intensities" = c(0.1, 0.1, 2))
-  expect_equal_sampling_result("rmo_esm", "test__rmo_esm_bivariate_R",
-                               args, n, use_seed)
-
-  ## exchangeable, high, low
-  args <- list("d" = 2L, "intensities" = c(3, 3, 0.5))
-  expect_equal_sampling_result("rmo_esm", "test__rmo_esm_bivariate_R",
-                               args, n, use_seed)
-
-  ## Low, High, Low
-  args[["intensities"]] <- c(0.5, 3, 0.2)
-  expect_equal_sampling_result("rmo_esm", "test__rmo_esm_bivariate_R",
-                               args, n, use_seed)
-
-  ## Low, Low, High
-  args[["intensities"]] <- c(0.1, 0.005, 2)
-  expect_equal_sampling_result("rmo_esm", "test__rmo_esm_bivariate_R",
-                               args, n, use_seed)
-
-  ## comonotone
-  args[["intensities"]] <- c(0, 0, 1)
-  expect_equal_sampling_result("rmo_esm", "test__rmo_esm_bivariate_R",
-                               args, n, use_seed)
+    args, n, use_seed)
 
   ## independence
   args[["intensities"]] <- c(1, 1, 0)
   expect_equal_sampling_result("rmo_esm", "test__rmo_esm_bivariate_R",
-                               args, n, use_seed)
+    args, n, use_seed)
+
+  ## comonotone
+  args[["intensities"]] <- c(0, 0, 1)
+  expect_equal_sampling_result("rmo_esm", "test__rmo_esm_bivariate_R",
+    args, n, use_seed)
+
+  ## exchangeable, low, high
+  args[["intensities"]] <- c(0.1, 0.1, 2)
+  expect_equal_sampling_result("rmo_esm", "test__rmo_esm_bivariate_R",
+    args, n, use_seed)
+
+  ## exchangeable, high, low
+  args[["intensities"]] <- c(3, 3, 0.5)
+  expect_equal_sampling_result("rmo_esm", "test__rmo_esm_bivariate_R",
+    args, n, use_seed)
+
+  ## Low, High, Low
+  args[["intensities"]] <- c(0.5, 3, 0.2)
+  expect_equal_sampling_result("rmo_esm", "test__rmo_esm_bivariate_R",
+    args, n, use_seed)
+
+  ## Low, Low, High
+  args[["intensities"]] <- c(0.1, 0.005, 2)
+  expect_equal_sampling_result("rmo_esm", "test__rmo_esm_bivariate_R",
+    args, n, use_seed)
 })
 
 
-
-## #### Test implementation against original `R` version ####
+# #### Test implementation against original `R` version ####
 #
 # Test that the Rcpp implementation of the exogenous shock model delivers the
 # same result as the `R` implementation for various dimensions and choices of
 # parameters.
 test_that("ESM implementation in C++", {
   # all equal
-  d <- 7L
+  d1 <- 3L
+  d2 <- 4L
+  d <- d1+d2
   intensities <- rep(0.5, times=2^d-1)
   args <- list("d" = d, "intensities" = intensities)
   expect_equal_sampling_result("rmo_esm", "test__rmo_esm_R",
     args, n, use_seed)
 
-  # d equal 4 and exchangeable
-  d <- 4L
-  intensities <- sapply(1:(2^d-1), function(x) {
-    cardinality <- sum(sapply(1:d, function(y) {
-      Rcpp__is_within(y, x)
-    }))
-
-    1 / cardinality
-  })
-  args <-list("d" = 4L, "intensities" = intensities)
+  # independence
+  args[["intensities"]] <- intensities_linear(d, scale=0.3)
   expect_equal_sampling_result("rmo_esm", "test__rmo_esm_R",
     args, n, use_seed)
 
-  ## TODO: Implement tests based on the parametrisation with Bernstein
-  ## functions to get realistic test-cases.
+  # comonotone
+  args[["intensities"]] <- intensities_constant(d, constant=0.7)
+  expect_equal_sampling_result("rmo_esm", "test__rmo_esm_R",
+    args, n, use_seed)
+
+  # Poisson
+  args[["intensities"]] <- intensities_poisson(d, lambda=0.2, eta=0.3)
+  expect_equal_sampling_result("rmo_esm", "test__rmo_esm_R",
+    args, n, use_seed)
+
+  # Alpha-Stable
+  args[["intensities"]] <- intensities_alpha_stable(d, alpha=0.25)
+  expect_equal_sampling_result("rmo_esm", "test__rmo_esm_R",
+    args, n, use_seed)
+
+  # Gamma
+  args[["intensities"]] <- intensities_alpha_stable(d, a=0.4)
+  expect_equal_sampling_result("rmo_esm", "test__rmo_esm_R",
+    args, n, use_seed)
+
+  # Hierarchical
+  args[["intensities"]] <- intensities_hierarchical(d1, d2,
+    lambda=0.1, eta=0.3, a=0.2, alpha=0.4)
+  expect_equal_sampling_result("rmo_esm", "test__rmo_esm_R",
+    args, n, use_seed)
 })


### PR DESCRIPTION
## Related issues

Closes/Fixes #28 

## Checklist

- [x] `R CMD CHECK` successful
- [x] tests included
- [x] documentation included or updated
- [x] commit messages follow [commit guidelines](https://udacity.github.io/git-styleguide/)

Only for new or refactored algorithms:

- [x] benchmarks (and comparison with the previous version) included

Optional, but recommended:

- [x] code passes `lintr::lint_package()` without errors

## Description

Review and refactoring of `rmo_esm` and related code. 

Proposed changes:
- Use `1<<d` instead of `pow(2., d)` 
- Only perform the minimum operation if the shock rate is not zero